### PR TITLE
Add modal overflow tests

### DIFF
--- a/site/gatsby-site/playwright/e2e/modalOverflow.spec.ts
+++ b/site/gatsby-site/playwright/e2e/modalOverflow.spec.ts
@@ -51,4 +51,50 @@ test.describe('Modals should not leave body overflow hidden', () => {
     await modal.waitFor({ state: 'hidden' });
     await ensureBodyOverflowNotHidden(page);
   });
+
+  test('flag report modal', async ({ page }) => {
+    await init();
+    await page.goto('/cite/1#1');
+    await page.locator('[id="r1"] [data-cy="expand-report-button"]').click();
+    await page.locator('[id="r1"] [data-cy="flag-button"]').click();
+    const modal = page.locator('[data-cy="flag-report-1"]');
+    await modal.waitFor();
+    await page.locator('[aria-label="Close"]').click();
+    await modal.waitFor({ state: 'hidden' });
+    await ensureBodyOverflowNotHidden(page);
+  });
+
+  test('authors modal', async ({ page }) => {
+    await page.goto('/cite/1#1');
+    await page.locator('[id="r1"] [data-cy="expand-report-button"]').click();
+    await page.getByRole('button', { name: 'Authors' }).click();
+    const modal = page.getByRole('dialog').filter({ hasText: 'Authors' });
+    await modal.waitFor();
+    await page.locator('[aria-label="Close"]').click();
+    await modal.waitFor({ state: 'hidden' });
+    await ensureBodyOverflowNotHidden(page);
+  });
+
+  test('submitters modal', async ({ page }) => {
+    await page.goto('/cite/1#1');
+    await page.locator('[id="r1"] [data-cy="expand-report-button"]').click();
+    await page.getByRole('button', { name: 'Submitters' }).click();
+    const modal = page.getByRole('dialog').filter({ hasText: 'Submitters' });
+    await modal.waitFor();
+    await page.locator('[aria-label="Close"]').click();
+    await modal.waitFor({ state: 'hidden' });
+    await ensureBodyOverflowNotHidden(page);
+  });
+
+  test('classification modal', async ({ page }) => {
+    await page.goto('/apps/classifications/');
+    const icon = page.locator('.fa-expand-arrows-alt').first();
+    await icon.scrollIntoViewIfNeeded();
+    await icon.click();
+    const modal = page.getByRole('dialog');
+    await modal.waitFor();
+    await page.locator('[aria-label="Close"]').click();
+    await modal.waitFor({ state: 'hidden' });
+    await ensureBodyOverflowNotHidden(page);
+  });
 });


### PR DESCRIPTION
## Summary
- expand modalOverflow.spec.ts to cover new modals

## Testing
- `npx playwright test site/gatsby-site/playwright/e2e/modalOverflow.spec.ts` *(fails: npm EHOSTUNREACH)*