### PR TITLE
Fix 404s from malformed discover URLs

### DIFF
--- a/site/gatsby-site/_redirects
+++ b/site/gatsby-site/_redirects
@@ -6,3 +6,4 @@
 /api/semanticallyRelated /.netlify/functions/semanticallyRelated 200
 /api/lookupbyurl /.netlify/functions/lookupbyurl 200
 /api/auth/* /.netlify/functions/auth 200
+/apps/discover/* /apps/discover 301

--- a/site/gatsby-site/deploy-netlify.toml
+++ b/site/gatsby-site/deploy-netlify.toml
@@ -42,3 +42,8 @@
   from = "/api/auth/*"
   to = "/.netlify/functions/auth"
   status = 200
+
+[[redirects]]
+  from = "/apps/discover/*"
+  to = "/apps/discover"
+  status = 301


### PR DESCRIPTION
## Summary
- add redirect rule to handle requests like `/apps/discover/<params>`
- include same rule in local `_redirects`

## Testing
- `npm run test:api`