### PR TITLE
Add typed value checks in classification tests

### DIFF
--- a/site/gatsby-site/server/scalars.ts
+++ b/site/gatsby-site/server/scalars.ts
@@ -1,4 +1,4 @@
-import { GraphQLScalarType, Kind } from "graphql";
+import { GraphQLScalarType, Kind, ValueNode } from "graphql";
 import { ObjectId } from "mongodb";
 
 export const ObjectIdScalar = new GraphQLScalarType({
@@ -22,5 +22,39 @@ export const ObjectIdScalar = new GraphQLScalarType({
         }
 
         return null;
+    },
+});
+
+function parseLiteralValue(ast: ValueNode): any {
+    switch (ast.kind) {
+        case Kind.STRING:
+        case Kind.BOOLEAN:
+            return ast.value;
+        case Kind.INT:
+            return parseInt(ast.value, 10);
+        case Kind.FLOAT:
+            return parseFloat(ast.value);
+        case Kind.LIST:
+            return ast.values.map(parseLiteralValue);
+        case Kind.OBJECT:
+            return Object.fromEntries(ast.fields.map(f => [f.name.value, parseLiteralValue(f.value)]));
+        case Kind.NULL:
+            return null;
+        default:
+            return null;
+    }
+}
+
+export const AttributeValueScalar = new GraphQLScalarType({
+    name: 'AttributeValue',
+    description: 'Value of classification attribute as typed data',
+    serialize(value: unknown) {
+        return value;
+    },
+    parseValue(value: unknown) {
+        return value;
+    },
+    parseLiteral(ast) {
+        return parseLiteralValue(ast);
     },
 });

--- a/site/gatsby-site/server/tests/fixtures/classifications.ts
+++ b/site/gatsby-site/server/tests/fixtures/classifications.ts
@@ -113,7 +113,7 @@ const classification1: DBClassification = {
     attributes: [
         {
             short_name: "Harm Distribution Basis",
-            value_json: "[]"
+            value_json: "[\"sexual orientation or gender identity\"]"
         },
         {
             short_name: "Sector of Deployment",
@@ -132,7 +132,7 @@ const classification2: DBClassification = {
     attributes: [
         {
             short_name: "Harm Distribution Basis",
-            value_json: "[]"
+            value_json: "[\"veteran status\"]"
         },
         {
             short_name: "Sector of Deployment",
@@ -272,6 +272,7 @@ const fixture: Fixture<Classification, any, ClassificationInsertType> = {
         attributes {
             short_name
             value_json
+            value
         }
         namespace
         notes
@@ -317,6 +318,18 @@ const fixture: Fixture<Classification, any, ClassificationInsertType> = {
             namespace: "CSETv1",
             reports: [{ report_number: 1 }],
             incidents: [{ incident_id: 1 }],
+            attributes: [
+                {
+                    short_name: "Harm Distribution Basis",
+                    value: ["sexual orientation or gender identity"],
+                    value_json: "[\"sexual orientation or gender identity\"]",
+                } as any,
+                {
+                    short_name: "Sector of Deployment",
+                    value: [],
+                    value_json: "[]",
+                } as any,
+            ]
         },
     },
     testPluralFilter: {
@@ -331,6 +344,18 @@ const fixture: Fixture<Classification, any, ClassificationInsertType> = {
                 namespace: "CSETv1",
                 reports: [{ report_number: 1 }],
                 incidents: [{ incident_id: 1 }],
+                attributes: [
+                    {
+                        short_name: "Harm Distribution Basis",
+                        value: ["sexual orientation or gender identity"],
+                        value_json: "[\"sexual orientation or gender identity\"]",
+                    } as any,
+                    {
+                        short_name: "Sector of Deployment",
+                        value: [],
+                        value_json: "[]",
+                    } as any,
+                ]
             }
         ]
     },

--- a/site/gatsby-site/server/types/classification.ts
+++ b/site/gatsby-site/server/types/classification.ts
@@ -1,5 +1,5 @@
 import { GraphQLObjectType, GraphQLString, GraphQLBoolean, GraphQLList, GraphQLInt, GraphQLNonNull, GraphQLID } from 'graphql';
-import { ObjectIdScalar } from '../scalars';
+import { ObjectIdScalar, AttributeValueScalar } from '../scalars';
 import { IncidentType } from './incidents';
 import { getListRelationshipConfig } from '../utils';
 import { ReportType } from './report';
@@ -8,7 +8,17 @@ const AttributeType = new GraphQLObjectType({
     name: 'Attribute',
     fields: {
         short_name: { type: GraphQLString },
-        value_json: { type: GraphQLString }
+        value_json: { type: GraphQLString },
+        value: {
+            type: AttributeValueScalar,
+            resolve: (source: any) => {
+                try {
+                    return JSON.parse(source.value_json);
+                } catch (e) {
+                    return source.value_json;
+                }
+            }
+        }
     }
 });
 


### PR DESCRIPTION
## Summary
- add specific attribute values to classification fixtures
- verify typed `value` field returns arrays in query results

## Testing
- `npm run test:api`


------
https://chatgpt.com/codex/tasks/task_e_6838c59a33348320af651997fdfd239e