### PR TITLE
Fix quiet reports showing in carousel

### DIFF
--- a/site/gatsby-site/page-creators/createLandingPage.js
+++ b/site/gatsby-site/page-creators/createLandingPage.js
@@ -22,6 +22,8 @@ const createLandingPage = async (graphql, createPage) => {
             text
             title
             url
+            is_incident_report
+            quiet
           }
         }
       }
@@ -62,14 +64,19 @@ const createLandingPage = async (graphql, createPage) => {
     }
   `);
 
-  const latestIncidents = result.data.latestIncidents.nodes;
+  const latestIncidents = result.data.latestIncidents.nodes.map((node) => {
+    const filteredReports = node.reports
+      .filter((r) => r.is_incident_report && !r.quiet)
+      .sort((a, b) => a.epoch_date_submitted - b.epoch_date_submitted);
 
-  const latestIncidentsReportNumbers = result.data.latestIncidents.nodes.map((node) => {
-    const sortedArray = node.reports.sort((a, b) => {
-      return a.epoch_date_submitted - b.epoch_date_submitted;
-    });
+    return {
+      ...node,
+      reports: filteredReports,
+    };
+  });
 
-    return sortedArray[0].report_number;
+  const latestIncidentsReportNumbers = latestIncidents.map((node) => {
+    return node.reports[0].report_number;
   });
 
   createPage({


### PR DESCRIPTION
## Summary
- exclude quiet reports from the LandingPage GraphQL query
- filter reports on the page creator to remove quiet ones before computing report numbers
- verify quiet flag persistence when editing reports

## Testing
- `npm --prefix site/gatsby-site run lint`
- `npm --prefix site/gatsby-site run test:api:ci` *(fails: Download failed for MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_6853136e07908320bede4b808f6a2724