### PR TITLE
Add magic link interstitial page

### DIFF
--- a/site/gatsby-site/nextauth.config.ts
+++ b/site/gatsby-site/nextauth.config.ts
@@ -30,6 +30,8 @@ export const getAuthConfig = async (req: any): Promise<NextAuthOptions> => {
         maxAge: 60 * 60 * 24, // Email link will expire in 24 hours
         async sendVerificationRequest({ identifier: email, url }: { identifier: string, url: string }) {
 
+          const interstitial = `${config.SITE_URL}/magic-link?link=${encodeURIComponent(url)}`;
+
           const user = await client.db('auth').collection('users').findOne({ email });
 
           if (user) {
@@ -38,7 +40,7 @@ export const getAuthConfig = async (req: any): Promise<NextAuthOptions> => {
               recipient: { email },
               subject: 'Secure link to log in to AIID',
               templateId: 'Login',
-              dynamicData: { magicLink: url },
+              dynamicData: { magicLink: `<a href="${interstitial}">${interstitial}</a>` },
             })
           }
           else {
@@ -47,7 +49,7 @@ export const getAuthConfig = async (req: any): Promise<NextAuthOptions> => {
               recipient: { email },
               subject: 'Secure link to create your AIID account',
               templateId: 'Signup',
-              dynamicData: { magicLink: url },
+              dynamicData: { magicLink: `<a href="${interstitial}">${interstitial}</a>` },
             })
           }
         }

--- a/site/gatsby-site/playwright/e2e/login.spec.ts
+++ b/site/gatsby-site/playwright/e2e/login.spec.ts
@@ -71,6 +71,8 @@ test.describe('Login', () => {
 
       await page.goto(magicLink);
 
+      await page.getByRole('button', { name: 'Continue' }).click();
+
       await expect(page).toHaveURL(redirectTo);
     }
   );

--- a/site/gatsby-site/playwright/utils.ts
+++ b/site/gatsby-site/playwright/utils.ts
@@ -130,7 +130,9 @@ export const generateMagicLink = async (email: string, callbackUrl = '/', roles:
     const baseUrl = config.NEXTAUTH_URL;
     const magicLink = `${baseUrl}/api/auth/callback/http-email?callbackUrl=${encodeURIComponent(baseUrl + callbackUrl)}&token=${token}&email=${encodeURIComponent(email)}`;
 
-    return magicLink;
+    const interstitialLink = `${baseUrl}/magic-link?link=${encodeURIComponent(magicLink)}`;
+
+    return interstitialLink;
 }
 
 async function getUserIdFromAuth(email: string) {
@@ -206,6 +208,8 @@ export const test = base.extend<TestFixtures>({
             await page.context().clearCookies();
 
             await page.goto(magicLink);
+
+            await page.getByRole('button', { name: 'Continue' }).click();
 
             const sessionToken = await getSessionToken(userId);
 

--- a/site/gatsby-site/server/tests/next-auth.spec.ts
+++ b/site/gatsby-site/server/tests/next-auth.spec.ts
@@ -139,7 +139,7 @@ describe('Auth', () => {
 
             expect(sendEmailMock).toHaveBeenCalledWith({
                 dynamicData: {
-                    magicLink: expect.stringMatching(/^http:\/\/localhost:8000\/api\/auth\/callback\/http-email\?callbackUrl=http%3A%2F%2Flocalhost%3A8000%2F&token=.+&email=test.user%40incidentdatabase.ai$/),
+                    magicLink: expect.stringMatching(/^<a href="http:\/\/localhost:8000\/magic-link\?link=http%3A%2F%2Flocalhost%3A8000%2Fapi%2Fauth%2Fcallback%2Fhttp-email.*<\/a>$/),
                 },
                 recipient: {
                     email: "test.user@incidentdatabase.ai",
@@ -188,7 +188,7 @@ describe('Auth', () => {
 
             expect(sendEmailMock).toHaveBeenCalledWith({
                 dynamicData: {
-                    magicLink: expect.stringMatching(/^http:\/\/localhost:8000\/api\/auth\/callback\/http-email\?callbackUrl=http%3A%2F%2Flocalhost%3A8000%2Fsome-path%2Fsome-page&token=.+&email=test.user%40incidentdatabase.ai$/),
+                    magicLink: expect.stringMatching(/^<a href="http:\/\/localhost:8000\/magic-link\?link=http%3A%2F%2Flocalhost%3A8000%2Fapi%2Fauth%2Fcallback%2Fhttp-email.*<\/a>$/),
                 },
                 recipient: {
                     email: "test.user@incidentdatabase.ai",
@@ -220,7 +220,7 @@ describe('Auth', () => {
 
             expect(sendEmailMock).toHaveBeenCalledWith({
                 dynamicData: {
-                    magicLink: expect.stringMatching(/^http:\/\/localhost:8000\/api\/auth\/callback\/http-email\?callbackUrl=http%3A%2F%2Flocalhost%3A8000%2F&token=.+&email=test.user%40incidentdatabase.ai$/),
+                    magicLink: expect.stringMatching(/^<a href="http:\/\/localhost:8000\/magic-link\?link=http%3A%2F%2Flocalhost%3A8000%2Fapi%2Fauth%2Fcallback%2Fhttp-email.*<\/a>$/),
                 },
                 recipient: {
                     email: "test.user@incidentdatabase.ai",
@@ -265,7 +265,7 @@ describe('Auth', () => {
 
             expect(sendEmailMock).toHaveBeenCalledWith({
                 dynamicData: {
-                    magicLink: expect.stringMatching(/^http:\/\/localhost:8000\/api\/auth\/callback\/http-email\?callbackUrl=http%3A%2F%2Flocalhost%3A8000%2F&token=.+&email=test.user%40incidentdatabase.ai$/),
+                    magicLink: expect.stringMatching(/^<a href="http:\/\/localhost:8000\/magic-link\?link=http%3A%2F%2Flocalhost%3A8000%2Fapi%2Fauth%2Fcallback%2Fhttp-email.*<\/a>$/),
                 },
                 recipient: {
                     email: "test.user@incidentdatabase.ai",
@@ -306,7 +306,7 @@ describe('Auth', () => {
 
             expect(sendEmailMock).toHaveBeenCalledWith({
                 dynamicData: {
-                    magicLink: expect.stringMatching(/^http:\/\/localhost:8000\/api\/auth\/callback\/http-email\?callbackUrl=http%3A%2F%2Flocalhost%3A8000%2Fsome-path%2Fsome-page&token=.+&email=test.user%40incidentdatabase.ai$/),
+                    magicLink: expect.stringMatching(/^<a href="http:\/\/localhost:8000\/magic-link\?link=http%3A%2F%2Flocalhost%3A8000%2Fapi%2Fauth%2Fcallback%2Fhttp-email.*<\/a>$/),
                 },
                 recipient: {
                     email: "test.user@incidentdatabase.ai",

--- a/site/gatsby-site/src/pages/magic-link.js
+++ b/site/gatsby-site/src/pages/magic-link.js
@@ -1,0 +1,48 @@
+import React, { useCallback } from 'react';
+import { Button } from 'flowbite-react';
+import { Trans, useTranslation } from 'react-i18next';
+import HeadContent from 'components/HeadContent';
+
+const MagicLink = ({ location }) => {
+  const params = new URLSearchParams(location.search);
+  const link = params.get('link');
+
+  const handleClick = useCallback(() => {
+    if (link) {
+      window.location.href = decodeURIComponent(link);
+    }
+  }, [link]);
+
+  if (!link) {
+    return (
+      <div>
+        <Trans>Invalid link</Trans>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 items-center">
+      <p>
+        <Trans>Click the button below to continue.</Trans>
+      </p>
+      <Button onClick={handleClick} data-cy="magic-link-btn">
+        <Trans>Continue</Trans>
+      </Button>
+    </div>
+  );
+};
+
+export const Head = (props) => {
+  const { t } = useTranslation();
+
+  return (
+    <HeadContent
+      metaTitle={t('AIID - Continue')}
+      path={props.location.pathname}
+      metaDescription={t('Continue to your destination')}
+    />
+  );
+};
+
+export default MagicLink;


### PR DESCRIPTION
## Summary
- add a `magic-link` page that redirects to the real NextAuth link after a click
- build interstitial URL into email magic link generation
- update Playwright helpers and tests for the new flow
- adjust NextAuth tests to check for the new email link format

## Testing
- `npm run test:api`

------
https://chatgpt.com/codex/tasks/task_e_68544dfbe7dc8320b1bc4da17a37315d