### PR TITLE
Add auto redirect to magic link interstitial

### DIFF
--- a/site/gatsby-site/playwright/e2e/login.spec.ts
+++ b/site/gatsby-site/playwright/e2e/login.spec.ts
@@ -71,9 +71,9 @@ test.describe('Login', () => {
 
       await page.goto(magicLink);
 
-      await page.getByRole('button', { name: 'Continue' }).click();
+      await expect(page.getByText('You will be redirected in 5 seconds.')).toBeVisible();
 
-      await expect(page).toHaveURL(redirectTo);
+      await page.waitForURL(redirectTo, { timeout: 7000 });
     }
   );
 

--- a/site/gatsby-site/playwright/e2e/magicLink.spec.ts
+++ b/site/gatsby-site/playwright/e2e/magicLink.spec.ts
@@ -1,0 +1,20 @@
+import { expect } from '@playwright/test';
+import { generateMagicLink, test } from '../utils';
+
+/**
+ * Tests for the /magic-link interstitial page.
+ */
+
+test.describe('Magic link interstitial', () => {
+  test('automatically redirects after a short delay', async ({ page }) => {
+    const redirectTo = '/account';
+
+    const magicLink = await generateMagicLink('test.user@incidentdatabase.ai', redirectTo);
+
+    await page.goto(magicLink);
+
+    await expect(page.getByText('You will be redirected in 5 seconds.')).toBeVisible();
+
+    await page.waitForURL(redirectTo, { timeout: 7000 });
+  });
+});

--- a/site/gatsby-site/src/pages/magic-link.js
+++ b/site/gatsby-site/src/pages/magic-link.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { Button } from 'flowbite-react';
 import { Trans, useTranslation } from 'react-i18next';
 import HeadContent from 'components/HeadContent';
@@ -14,6 +14,16 @@ const MagicLink = ({ location }) => {
     }
   }, [link]);
 
+  useEffect(() => {
+    if (link) {
+      const timer = setTimeout(() => {
+        window.location.href = decodeURIComponent(link);
+      }, 5000);
+
+      return () => clearTimeout(timer);
+    }
+  }, [link]);
+
   if (!link) {
     return (
       <div>
@@ -26,6 +36,9 @@ const MagicLink = ({ location }) => {
     <div className="flex flex-col gap-4 items-center">
       <p>
         <Trans>Click the button below to continue.</Trans>
+      </p>
+      <p>
+        <Trans>You will be redirected in 5 seconds.</Trans>
       </p>
       <Button onClick={handleClick} data-cy="magic-link-btn">
         <Trans>Continue</Trans>


### PR DESCRIPTION
## Summary
- auto redirect from the `/magic-link` interstitial page after 5 seconds
- update login e2e test to wait for automatic redirect
- add new e2e test covering the magic link page

## Testing
- `npm run test:api`
- `npm run lint`
- `npm run test:e2e` *(fails: headed browser requires X server)*
- `npm run test:e2e:ci` *(fails: unable to start web server, network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685591f5a0bc83209d53a79a6267a120