### PR TITLE
Magic link auto redirect

### DIFF
--- a/site/gatsby-site/src/pages/magic-link.js
+++ b/site/gatsby-site/src/pages/magic-link.js
@@ -1,5 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { Button } from 'flowbite-react';
+import React, { useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import HeadContent from 'components/HeadContent';
 
@@ -15,23 +14,11 @@ const MagicLink = ({ location }) => {
 
     setLink(linkParam);
     setIsLoading(false);
+
+    if (linkParam) {
+      window.location.href = decodeURIComponent(linkParam);
+    }
   }, [location.search]);
-
-  const handleClick = useCallback(() => {
-    if (link) {
-      window.location.href = decodeURIComponent(link);
-    }
-  }, [link]);
-
-  useEffect(() => {
-    if (link) {
-      const timer = setTimeout(() => {
-        window.location.href = decodeURIComponent(link);
-      }, 5000);
-
-      return () => clearTimeout(timer);
-    }
-  }, [link]);
 
   if (isLoading) {
     return (
@@ -56,14 +43,8 @@ const MagicLink = ({ location }) => {
   return (
     <div className="flex flex-col gap-4 items-center">
       <p>
-        <Trans>
-          You will be redirected automatically in 5 seconds, or click the button below to continue
-          now.
-        </Trans>
+        <Trans>Redirecting...</Trans>
       </p>
-      <Button onClick={handleClick} data-cy="magic-link-btn">
-        <Trans>Continue</Trans>
-      </Button>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- auto-redirect user when magic link page loads
- drop the continue button

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: headed browser requires X server)*
- `npm run test:api`


------
https://chatgpt.com/codex/tasks/task_e_685c2f0ef2b88320938e7fa55c2d619f